### PR TITLE
Accessibility: Add focus styles

### DIFF
--- a/content/blog/hello.md
+++ b/content/blog/hello.md
@@ -18,4 +18,4 @@ plus m n =
     m + n
 ```
 
-[This is a link back home](/)
+[See all posts](/blog)

--- a/content/blog/hello.md
+++ b/content/blog/hello.md
@@ -17,3 +17,5 @@ plus : number -> number -> number
 plus m n =
     m + n
 ```
+
+[This is a link back home](/)

--- a/src/Index.elm
+++ b/src/Index.elm
@@ -9,6 +9,7 @@ import Metadata exposing (Metadata)
 import Pages
 import Pages.PagePath as PagePath exposing (PagePath)
 import Pages.Platform exposing (Page)
+import Palette
 
 
 view :
@@ -50,7 +51,9 @@ postSummary ( postPath, post ) =
 
 linkToPost : PagePath Pages.PathKey -> Element msg -> Element msg
 linkToPost postPath content =
-    Element.link [ Element.width Element.fill ]
+    Palette.link
+        [ Element.width Element.fill
+        ]
         { url = PagePath.toString postPath, label = content }
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -116,7 +116,17 @@ view model siteMetadata page =
     { title = title
     , body =
         body
-            |> Element.layout
+            |> Element.layoutWith
+                { options =
+                    -- We set focus styles for interactable elements. See Palette.elm for more detais.
+                    -- Note that currently these do not apply to links by default.
+                    [ Element.focusStyle
+                        { borderColor = Nothing
+                        , backgroundColor = Nothing
+                        , shadow = Just Palette.focusStyleShadow
+                        }
+                    ]
+                }
                 [ Element.width Element.fill
                 , Font.size 20
                 , Font.family [ Font.typeface "Roboto" ]
@@ -239,7 +249,7 @@ header currentPath =
             , Element.Border.widthEach { bottom = 1, left = 0, right = 0, top = 0 }
             , Element.Border.color (Element.rgba255 40 80 40 0.4)
             ]
-            [ Element.link []
+            [ Palette.link []
                 { url = "/"
                 , label =
                     Element.row [ Font.size 30, Element.spacing 16 ]
@@ -266,7 +276,7 @@ highlightableLink currentPath linkDirectory displayName =
         isHighlighted =
             currentPath |> Directory.includes linkDirectory
     in
-    Element.link
+    Palette.link
         (if isHighlighted then
             [ Font.underline
             , Font.color Palette.color.primary
@@ -397,7 +407,7 @@ publishedDateView metadata =
 
 githubRepoLink : Element msg
 githubRepoLink =
-    Element.newTabLink []
+    Palette.newTabLink []
         { url = "https://github.com/dillonkearns/elm-pages"
         , label =
             Element.image
@@ -410,7 +420,7 @@ githubRepoLink =
 
 elmDocsLink : Element msg
 elmDocsLink =
-    Element.newTabLink []
+    Palette.newTabLink []
         { url = "https://package.elm-lang.org/packages/dillonkearns/elm-pages/latest/"
         , label =
             Element.image

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -258,9 +258,11 @@ header currentPath =
                         ]
                 }
             , Element.row [ Element.spacing 15 ]
-                [ elmDocsLink
-                , githubRepoLink
-                , highlightableLink currentPath pages.blog.directory "Blog"
+                -- Wrap each item in a single element, to avoid an elm-ui focus bug
+                -- @see https://github.com/mdgriffith/elm-ui/issues/47
+                [ Element.el [] elmDocsLink
+                , Element.el [] githubRepoLink
+                , Element.el [] (highlightableLink currentPath pages.blog.directory "Blog")
                 ]
             ]
         ]

--- a/src/Palette.elm
+++ b/src/Palette.elm
@@ -1,6 +1,8 @@
-module Palette exposing (blogHeading, color, heading)
+module Palette exposing (blogHeading, color, focusStyleShadow, heading, link, newTabLink)
 
+import Color exposing (Color)
 import Element exposing (Element)
+import Element.Border
 import Element.Font as Font
 import Element.Region
 
@@ -9,6 +11,71 @@ color =
     { primary = Element.rgb255 5 117 230
     , secondary = Element.rgb255 0 242 96
     }
+
+
+{-| A box-shadow record, compatible both with `Element.layoutWith` Option and `Element.focusStyle`.
+
+For buttons, links and other interactables, we set focus styles
+We use a box-shadow instead of an outline, because it follows borders.
+
+Blue works well in this particular case.
+You might want to customise this for your application.
+
+Bear in mind that focus outlines should not be removed altogether,
+because they are used by people who rely on keyboard and/or screen reader navigation.
+They should also have a good color contrast with the background.
+
+-}
+focusStyleShadow =
+    { color = color.primary
+    , offset = ( 0, 0 )
+    , blur = 0
+    , size = 2
+    }
+
+
+{-| A composable `Element.link` that bakes in focus styles.
+
+We need this for consistent / good-by-default styles and accessibility.
+This might change in the future, if elm-ui supports setting focus globally via layoutWith.
+
+See the notes in focusStyleShadow for more on accessibility and styling.
+
+-}
+link :
+    List (Element.Attribute msg)
+    ->
+        { url : String
+        , label : Element msg
+        }
+    -> Element msg
+link attrs content =
+    Element.link
+        (Element.focused
+            [ Element.Border.shadow focusStyleShadow
+            ]
+            :: attrs
+        )
+        content
+
+
+{-| A composable `Element.newTabLink` that bakes in focus styles.
+-}
+newTabLink :
+    List (Element.Attribute msg)
+    ->
+        { url : String
+        , label : Element msg
+        }
+    -> Element msg
+newTabLink attrs content =
+    Element.newTabLink
+        (Element.focused
+            [ Element.Border.shadow focusStyleShadow
+            ]
+            :: attrs
+        )
+        content
 
 
 heading : Int -> List (Element msg) -> Element msg


### PR DESCRIPTION
Hello @dillonkearns!

Here with the PR for focus styles, as promised :) (Closes #2 )

It is a small PR code-wise, but I think the conceptual parts are larger.

What I'm aiming for is to enable people to adjust the styles to their application, without nuking them altogether. To that end, I left a few comments in the code and tried to centralise them in `Palette`. I went with the blue colour already present. Blue works quite well for contrast (part of why it's the browser default). I also went with box-shadows, because they follow borders, such as in rounded buttons.

The `elm-ui` APIs for focus styles are a bit rough in my experience. The `layoutWith` options only apply to buttons, but not to links. I've had to do this same exercise at a work project, and there were always a couple of places to add focus styles. That's the main reason for containing them in `Palette`.

## About Markdown Links

There is one part that I'm a bit stuck (not a blocker necessarily).

In the starter, links in Markdown have the default browser link styles, and I do not understand how that's possible! (Running locally at http://localhost:3000/blog/hello). 

Meanwhile, in the elm-pages demo site (at https://elm-pages.com/blog/introducing-elm-pages), the links inside Markdown do not have link styles at all.

This to me hints that the former are not under `elm-ui`, but the latter somehow are? Could you point me to the part of the code that handles that? I think that's the final place where we can have the "good by default" behaviour, or to add comments etc.

## Aside about elm-ui

I'm adding a couple of thoughts about elm-ui for accessibility here.
I'm doing it mostly because this is a good example of a large project using it, and it can showcase the API decisions and implications for accessibility.

If you have a contact with Matthew, I'd love to bring them up with him. I have extremely limited time and energy, and the impression I have so far is that much of elm-ui is focused on perf/V2. I'll probably post these to the elm-ui tracker if they look good to you.

### 1) Focus options

In Windows High-Contrast Mode (WHCM), used approximately by 4% of folks on Windows, box-shadows are hidden. This is by design. In those cases, preserving an outline (even transparent) will mean that it is visible in WHCM. This is something that should change at the `elm-ui` level, to either allow outlines, or include a transparent one by default.

### 2) Opt-in vs opt-out

Something we mentioned on Twitter, would be to have the default browser focus styles if not otherwise specified. I am skeptical of people opting-in to them, and removing them without prompting the developers to replace them is a bit scary.

Similarly, something that came up would be a focus style constructor for browser defaults, such as `Element.defaultFocusStyle` .

### 3) `layoutWith`

Something I'm wondering is why `layoutWith` does not apply focus to links. I would guess that they can always be overridden with `Element.focusStyle`. Is it an omission? Something that was considered? I'm not sure! I think it would make things easier for rendering links in Markdown, where specifying focus styles ad-hoc is hard/impossible.

## Wrapping up

Thank you for your time and willingness to integrate these!