### PR TITLE
Better decode.fail messages

### DIFF
--- a/src/Metadata.elm
+++ b/src/Metadata.elm
@@ -87,7 +87,12 @@ imageDecoder =
             (\imageAssetPath ->
                 case findMatchingImage imageAssetPath of
                     Nothing ->
-                        Decode.fail "Couldn't find image."
+                        "I couldn't find that. Available images are:\n"
+                            :: List.map
+                                ((\x -> "\t\"" ++ x ++ "\"") << ImagePath.toString)
+                                Pages.allImages
+                            |> String.join "\n"
+                            |> Decode.fail
 
                     Just imagePath ->
                         Decode.succeed imagePath


### PR DESCRIPTION
Hello!

I've found it easier in my own project to list all the correct values when I have a typo for the images. 

Old message:

```
ERROR in -- METADATA DECODE ERROR --- elm-pages

I ran into a problem when parsing the metadata for the page with this path: blog/hello

Problem with the value at json.image:

    "images/article-covers/hello.jpeg"

Couldn't find image.
```

New message:
```
ERROR in -- METADATA DECODE ERROR --- elm-pages

I ran into a problem when parsing the metadata for the page with this path: blog/hello

Problem with the value at json.image:

    "images/article-covers/hello.jpeg"

I couldn't find that. Available images are:

	"images/article-covers/hello.jpg"
	"images/article-covers/mountains.jpg"
	"images/author/dillon.jpg"
	"images/elm-logo.svg"
	"images/github.svg"
	"images/icon-png.png"
	"images/icon.svg"
```

Hope you find this useful.