### PR TITLE
Improve code for Metadata

### DIFF
--- a/src/Metadata.elm
+++ b/src/Metadata.elm
@@ -2,8 +2,6 @@ module Metadata exposing (ArticleMetadata, Metadata(..), PageMetadata, decoder)
 
 import Data.Author
 import Date exposing (Date)
-import Dict exposing (Dict)
-import Element exposing (Element)
 import Json.Decode as Decode exposing (Decoder)
 import List.Extra
 import Pages
@@ -31,6 +29,7 @@ type alias PageMetadata =
     { title : String }
 
 
+decoder : Decoder Metadata
 decoder =
     Decode.field "type" Decode.string
         |> Decode.andThen
@@ -76,7 +75,7 @@ decoder =
                             |> Decode.map Article
 
                     _ ->
-                        Decode.fail <| "Unexpected page type " ++ pageType
+                        Decode.fail ("Unexpected page type " ++ pageType)
             )
 
 


### PR DESCRIPTION
- Remove unused imports
- Add missing type annotation for `decoder`
- Use parens instead of `<|`