### PR TITLE
Improve code style of DocumentSvg

### DIFF
--- a/src/DocumentSvg.elm
+++ b/src/DocumentSvg.elm
@@ -2,8 +2,8 @@ module DocumentSvg exposing (view)
 
 import Color exposing (Color)
 import Element exposing (Element)
-import Svg exposing (Svg)
-import Svg.Attributes as Attr
+import Svg exposing (..)
+import Svg.Attributes exposing (..)
 
 
 strokeColor : String
@@ -30,21 +30,21 @@ fillGradient =
 
 gradient : Color -> Color -> Svg msg
 gradient color1 color2 =
-    Svg.linearGradient
-        [ Attr.id "grad1"
-        , Attr.x1 "0%"
-        , Attr.y1 "0%"
-        , Attr.x2 "100%"
-        , Attr.y2 "0%"
+    linearGradient
+        [ id "grad1"
+        , x1 "0%"
+        , y1 "0%"
+        , x2 "100%"
+        , y2 "0%"
         ]
-        [ Svg.stop
-            [ Attr.offset "10%"
-            , Attr.style ("stop-color:" ++ Color.toCssString color1 ++ ";stop-opacity:1")
+        [ stop
+            [ offset "10%"
+            , Svg.Attributes.style ("stop-color:" ++ Color.toCssString color1 ++ ";stop-opacity:1")
             ]
             []
-        , Svg.stop
-            [ Attr.offset "100%"
-            , Attr.style ("stop-color:" ++ Color.toCssString color2 ++ ";stop-opacity:1")
+        , stop
+            [ offset "100%"
+            , Svg.Attributes.style ("stop-color:" ++ Color.toCssString color2 ++ ";stop-opacity:1")
             ]
             []
         ]
@@ -52,93 +52,93 @@ gradient color1 color2 =
 
 view : Element msg
 view =
-    Svg.svg
-        [ Attr.version "1.1"
-        , Attr.viewBox "251.0485 144.52063 56.114286 74.5"
-        , Attr.width "56.114286"
-        , Attr.height "74.5"
-        , Attr.width "30px"
+    svg
+        [ version "1.1"
+        , viewBox "251.0485 144.52063 56.114286 74.5"
+        , width "56.114286"
+        , height "74.5"
+        , width "30px"
         ]
-        [ Svg.defs []
+        [ defs []
             [ fillGradient ]
-        , Svg.metadata [] []
-        , Svg.g
-            [ Attr.id "Canvas_11"
-            , Attr.stroke "none"
-            , Attr.fill fillColor
-            , Attr.strokeOpacity "1"
-            , Attr.fillOpacity "1"
-            , Attr.strokeDasharray "none"
+        , metadata [] []
+        , g
+            [ id "Canvas_11"
+            , stroke "none"
+            , fill fillColor
+            , strokeOpacity "1"
+            , fillOpacity "1"
+            , strokeDasharray "none"
             ]
-            [ Svg.g [ Attr.id "Canvas_11: Layer 1" ]
-                [ Svg.g [ Attr.id "Group_38" ]
-                    [ Svg.g [ Attr.id "Graphic_32" ]
+            [ g [ id "Canvas_11: Layer 1" ]
+                [ g [ id "Group_38" ]
+                    [ g [ id "Graphic_32" ]
                         [ Svg.path
-                            [ Attr.d "M 252.5485 146.02063 L 252.5485 217.52063 L 305.66277 217.52063 L 305.66277 161.68254 L 290.00087 146.02063 Z"
-                            , Attr.stroke strokeColor
-                            , Attr.strokeLinecap "round"
-                            , Attr.strokeLinejoin "round"
-                            , Attr.strokeWidth "3"
+                            [ d "M 252.5485 146.02063 L 252.5485 217.52063 L 305.66277 217.52063 L 305.66277 161.68254 L 290.00087 146.02063 Z"
+                            , stroke strokeColor
+                            , strokeLinecap "round"
+                            , strokeLinejoin "round"
+                            , strokeWidth "3"
                             ]
                             []
                         ]
-                    , Svg.g
-                        [ Attr.id "Line_34"
+                    , g
+                        [ id "Line_34"
                         ]
-                        [ Svg.line
-                            [ Attr.x1 "266.07286"
-                            , Attr.y1 "182.8279"
-                            , Attr.x2 "290.75465"
-                            , Attr.y2 "183.00997"
-                            , Attr.stroke pageTextColor
-                            , Attr.strokeLinecap "round"
-                            , Attr.strokeLinejoin "round"
-                            , Attr.strokeWidth "2"
+                        [ line
+                            [ x1 "266.07286"
+                            , y1 "182.8279"
+                            , x2 "290.75465"
+                            , y2 "183.00997"
+                            , stroke pageTextColor
+                            , strokeLinecap "round"
+                            , strokeLinejoin "round"
+                            , strokeWidth "2"
                             ]
                             []
                         ]
-                    , Svg.g
-                        [ Attr.id "Line_35"
+                    , g
+                        [ id "Line_35"
                         ]
-                        [ Svg.line
-                            [ Attr.x1 "266.07286"
-                            , Attr.y1 "191.84156"
-                            , Attr.x2 "290.75465"
-                            , Attr.y2 "192.02363"
-                            , Attr.stroke pageTextColor
-                            , Attr.strokeLinecap "round"
-                            , Attr.strokeLinejoin "round"
-                            , Attr.strokeWidth "2"
+                        [ line
+                            [ x1 "266.07286"
+                            , y1 "191.84156"
+                            , x2 "290.75465"
+                            , y2 "192.02363"
+                            , stroke pageTextColor
+                            , strokeLinecap "round"
+                            , strokeLinejoin "round"
+                            , strokeWidth "2"
                             ]
                             []
                         ]
-                    , Svg.g
-                        [ Attr.id "Line_36"
+                    , g
+                        [ id "Line_36"
                         ]
-                        [ Svg.line
-                            [ Attr.x1 "266.07286"
-                            , Attr.y1 "200.85522"
-                            , Attr.x2 "290.75465"
-                            , Attr.y2 "201.0373"
-                            , Attr.stroke pageTextColor
-                            , Attr.strokeLinecap "round"
-                            , Attr.strokeLinejoin "round"
-                            , Attr.strokeWidth "2"
+                        [ line
+                            [ x1 "266.07286"
+                            , y1 "200.85522"
+                            , x2 "290.75465"
+                            , y2 "201.0373"
+                            , stroke pageTextColor
+                            , strokeLinecap "round"
+                            , strokeLinejoin "round"
+                            , strokeWidth "2"
                             ]
                             []
                         ]
-                    , Svg.g
-                        [ Attr.id "Line_37"
+                    , g
+                        [ id "Line_37"
                         ]
-                        [ Svg.line
-                            [ Attr.x1 "266.07286"
-                            , Attr.y1 "164.80058"
-                            , Attr.x2 "278.3874"
-                            , Attr.y2 "164.94049"
-                            , Attr.stroke pageTextColor
-                            , Attr.strokeLinecap "round"
-                            , Attr.strokeLinejoin "round"
-                            , Attr.strokeWidth "2"
+                        [ line
+                            [ x1 "266.07286"
+                            , y1 "164.80058"
+                            , x2 "278.3874"
+                            , y2 "164.94049"
+                            , stroke pageTextColor
+                            , strokeLinecap "round"
+                            , strokeLinejoin "round"
+                            , strokeWidth "2"
                             ]
                             []
                         ]

--- a/src/DocumentSvg.elm
+++ b/src/DocumentSvg.elm
@@ -1,88 +1,147 @@
 module DocumentSvg exposing (view)
 
-import Color
+import Color exposing (Color)
 import Element exposing (Element)
-import Svg exposing (..)
-import Svg.Attributes exposing (..)
+import Svg exposing (Svg)
+import Svg.Attributes as Attr
 
 
+strokeColor : String
 strokeColor =
-    -- "url(#grad1)"
     "black"
 
 
+pageTextColor : String
 pageTextColor =
     "black"
 
 
+fillColor : String
 fillColor =
     "url(#grad1)"
 
 
-
--- "none"
-
-
+fillGradient : Svg msg
 fillGradient =
     gradient
         (Color.rgb255 5 117 230)
         (Color.rgb255 0 242 96)
 
 
-
--- (Color.rgb255 252 0 255)
--- (Color.rgb255 0 219 222)
--- (Color.rgb255 255 93 194)
--- (Color.rgb255 255 150 250)
-
-
+gradient : Color -> Color -> Svg msg
 gradient color1 color2 =
-    linearGradient [ id "grad1", x1 "0%", y1 "0%", x2 "100%", y2 "0%" ]
-        [ stop
-            [ offset "10%"
-            , Svg.Attributes.style ("stop-color:" ++ Color.toCssString color1 ++ ";stop-opacity:1")
+    Svg.linearGradient
+        [ Attr.id "grad1"
+        , Attr.x1 "0%"
+        , Attr.y1 "0%"
+        , Attr.x2 "100%"
+        , Attr.y2 "0%"
+        ]
+        [ Svg.stop
+            [ Attr.offset "10%"
+            , Attr.style ("stop-color:" ++ Color.toCssString color1 ++ ";stop-opacity:1")
             ]
             []
-        , stop [ offset "100%", Svg.Attributes.style ("stop-color:" ++ Color.toCssString color2 ++ ";stop-opacity:1") ] []
+        , Svg.stop
+            [ Attr.offset "100%"
+            , Attr.style ("stop-color:" ++ Color.toCssString color2 ++ ";stop-opacity:1")
+            ]
+            []
         ]
 
 
 view : Element msg
 view =
-    svg
-        [ version "1.1"
-        , viewBox "251.0485 144.52063 56.114286 74.5"
-        , width "56.114286"
-        , height "74.5"
-        , Svg.Attributes.width "30px"
+    Svg.svg
+        [ Attr.version "1.1"
+        , Attr.viewBox "251.0485 144.52063 56.114286 74.5"
+        , Attr.width "56.114286"
+        , Attr.height "74.5"
+        , Attr.width "30px"
         ]
-        [ defs []
+        [ Svg.defs []
             [ fillGradient ]
-        , metadata [] []
-        , g
-            [ id "Canvas_11"
-            , stroke "none"
-            , fill fillColor
-            , strokeOpacity "1"
-            , fillOpacity "1"
-            , strokeDasharray "none"
+        , Svg.metadata [] []
+        , Svg.g
+            [ Attr.id "Canvas_11"
+            , Attr.stroke "none"
+            , Attr.fill fillColor
+            , Attr.strokeOpacity "1"
+            , Attr.fillOpacity "1"
+            , Attr.strokeDasharray "none"
             ]
-            [ g [ id "Canvas_11: Layer 1" ]
-                [ g [ id "Group_38" ]
-                    [ g [ id "Graphic_32" ]
+            [ Svg.g [ Attr.id "Canvas_11: Layer 1" ]
+                [ Svg.g [ Attr.id "Group_38" ]
+                    [ Svg.g [ Attr.id "Graphic_32" ]
                         [ Svg.path
-                            [ d "M 252.5485 146.02063 L 252.5485 217.52063 L 305.66277 217.52063 L 305.66277 161.68254 L 290.00087 146.02063 Z"
-                            , stroke strokeColor
-                            , strokeLinecap "round"
-                            , strokeLinejoin "round"
-                            , strokeWidth "3"
+                            [ Attr.d "M 252.5485 146.02063 L 252.5485 217.52063 L 305.66277 217.52063 L 305.66277 161.68254 L 290.00087 146.02063 Z"
+                            , Attr.stroke strokeColor
+                            , Attr.strokeLinecap "round"
+                            , Attr.strokeLinejoin "round"
+                            , Attr.strokeWidth "3"
                             ]
                             []
                         ]
-                    , g [ id "Line_34" ] [ line [ x1 "266.07286", y1 "182.8279", x2 "290.75465", y2 "183.00997", stroke pageTextColor, strokeLinecap "round", strokeLinejoin "round", strokeWidth "2" ] [] ]
-                    , g [ id "Line_35" ] [ line [ x1 "266.07286", y1 "191.84156", x2 "290.75465", y2 "192.02363", stroke pageTextColor, strokeLinecap "round", strokeLinejoin "round", strokeWidth "2" ] [] ]
-                    , g [ id "Line_36" ] [ line [ x1 "266.07286", y1 "200.85522", x2 "290.75465", y2 "201.0373", stroke pageTextColor, strokeLinecap "round", strokeLinejoin "round", strokeWidth "2" ] [] ]
-                    , g [ id "Line_37" ] [ line [ x1 "266.07286", y1 "164.80058", x2 "278.3874", y2 "164.94049", stroke pageTextColor, strokeLinecap "round", strokeLinejoin "round", strokeWidth "2" ] [] ]
+                    , Svg.g
+                        [ Attr.id "Line_34"
+                        ]
+                        [ Svg.line
+                            [ Attr.x1 "266.07286"
+                            , Attr.y1 "182.8279"
+                            , Attr.x2 "290.75465"
+                            , Attr.y2 "183.00997"
+                            , Attr.stroke pageTextColor
+                            , Attr.strokeLinecap "round"
+                            , Attr.strokeLinejoin "round"
+                            , Attr.strokeWidth "2"
+                            ]
+                            []
+                        ]
+                    , Svg.g
+                        [ Attr.id "Line_35"
+                        ]
+                        [ Svg.line
+                            [ Attr.x1 "266.07286"
+                            , Attr.y1 "191.84156"
+                            , Attr.x2 "290.75465"
+                            , Attr.y2 "192.02363"
+                            , Attr.stroke pageTextColor
+                            , Attr.strokeLinecap "round"
+                            , Attr.strokeLinejoin "round"
+                            , Attr.strokeWidth "2"
+                            ]
+                            []
+                        ]
+                    , Svg.g
+                        [ Attr.id "Line_36"
+                        ]
+                        [ Svg.line
+                            [ Attr.x1 "266.07286"
+                            , Attr.y1 "200.85522"
+                            , Attr.x2 "290.75465"
+                            , Attr.y2 "201.0373"
+                            , Attr.stroke pageTextColor
+                            , Attr.strokeLinecap "round"
+                            , Attr.strokeLinejoin "round"
+                            , Attr.strokeWidth "2"
+                            ]
+                            []
+                        ]
+                    , Svg.g
+                        [ Attr.id "Line_37"
+                        ]
+                        [ Svg.line
+                            [ Attr.x1 "266.07286"
+                            , Attr.y1 "164.80058"
+                            , Attr.x2 "278.3874"
+                            , Attr.y2 "164.94049"
+                            , Attr.stroke pageTextColor
+                            , Attr.strokeLinecap "round"
+                            , Attr.strokeLinejoin "round"
+                            , Attr.strokeWidth "2"
+                            ]
+                            []
+                        ]
                     ]
                 ]
             ]


### PR DESCRIPTION
- Qualify functions from Svg and Svg.Attributes (as Attr) to stop importing everything.
- Add missing type annotations
- Avoid long lines